### PR TITLE
docs: bootstrap Zensical documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - master
+      - main
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - run: pip install zensical
+      - run: zensical build --clean
+      - name: Strip leaked template overrides
+        run: rm -rf site/overrides
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+      - uses: actions/deploy-pages@v5
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/site
+/.cache

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,0 +1,118 @@
+/* --------------------------------------------------------------------------
+ * Home hero
+ * Applied to docs/index.md via overrides/home.html.
+ * -------------------------------------------------------------------------- */
+
+.cx-hero {
+  background:
+    radial-gradient(circle at 0% 0%, rgba(99, 102, 241, 0.18), transparent 55%),
+    radial-gradient(circle at 100% 100%, rgba(236, 72, 153, 0.14), transparent 55%),
+    linear-gradient(180deg, var(--md-default-bg-color) 0%, var(--md-default-bg-color) 100%);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  padding: 4rem 0 3.5rem;
+}
+
+[data-md-color-scheme="slate"] .cx-hero {
+  background:
+    radial-gradient(circle at 0% 0%, rgba(129, 140, 248, 0.20), transparent 55%),
+    radial-gradient(circle at 100% 100%, rgba(244, 114, 182, 0.18), transparent 55%),
+    linear-gradient(180deg, var(--md-default-bg-color) 0%, var(--md-default-bg-color) 100%);
+}
+
+.cx-hero__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 1000px) {
+  .cx-hero__inner {
+    grid-template-columns: 1fr;
+    gap: 2.25rem;
+  }
+}
+
+.cx-hero__eyebrow {
+  margin: 0 0 0.9rem;
+}
+
+.cx-hero__badge {
+  display: inline-block;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--md-primary-fg-color);
+  background: color-mix(in srgb, var(--md-primary-fg-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-primary-fg-color) 30%, transparent);
+  border-radius: 999px;
+}
+
+.cx-hero__title {
+  margin: 0 0 1rem;
+  font-size: 4rem;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--md-primary-fg-color), color-mix(in srgb, var(--md-primary-fg-color) 50%, #ec4899));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.cx-hero__subtitle {
+  margin: 0 0 2rem;
+  font-size: 1.1rem;
+  line-height: 1.55;
+  color: var(--md-default-fg-color--light);
+  max-width: 36rem;
+}
+
+.cx-hero__subtitle code {
+  font-size: 0.9em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.35rem;
+  background: var(--md-code-bg-color);
+  color: var(--md-code-fg-color);
+}
+
+.cx-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cx-hero__cta {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.cx-hero__preview pre {
+  margin: 0;
+  padding: 1.4rem 1.5rem;
+  background: var(--md-code-bg-color);
+  color: var(--md-code-fg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.85rem;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  box-shadow:
+    0 30px 60px -25px rgba(15, 23, 42, 0.35),
+    0 8px 20px -10px rgba(15, 23, 42, 0.25);
+}
+
+[data-md-color-scheme="slate"] .cx-hero__preview pre {
+  box-shadow:
+    0 30px 60px -25px rgba(0, 0, 0, 0.7),
+    0 8px 20px -10px rgba(0, 0, 0, 0.5);
+}
+
+/* Lightweight TOML token coloring — reads the existing pygments palette so it
+ * matches whichever scheme is active. Falls back to sane defaults. */
+.cx-tok-key  { color: var(--md-code-hl-name-color, #6f42c1); font-weight: 600; }
+.cx-tok-attr { color: var(--md-code-hl-keyword-color, #0550ae); }
+.cx-tok-str  { color: var(--md-code-hl-string-color, #0a7f4f); }
+.cx-tok-num  { color: var(--md-code-hl-number-color, #b45309); }

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,0 +1,25 @@
+---
+icon: lucide/puzzle
+---
+
+# Components
+
+Courier ships with a small set of built-in components. Every one of them is registered against the [component registry](../concepts/architecture.md#component-registry) under a short `kind` string that you reference in `config.toml`.
+
+| Role      | Built-in `kind`s |
+| --------- | ---------------- |
+| Source    | `api_poll`, `kafka` |
+| Transform | `set_key`, `script` |
+| Sink      | `kafka` |
+
+Each role has its own namespace, so `"kafka"` is both a source and a sink without collision.
+
+## In this section
+
+- **[Sources](sources.md)** — `api_poll`, `kafka`.
+- **[Transforms](transforms.md)** — `set_key`, `script` (Rhai / Lua / Python).
+- **[Sinks](sinks.md)** — `kafka`, plus the `ManagedSink` retry/dead-letter wrapper.
+
+## Adding your own
+
+External components live in their own crate and call a `register(&mut registry)` function before `Courier` is built. See [Contributing](../contributing.md) for the full plugin walkthrough.

--- a/docs/components/sinks.md
+++ b/docs/components/sinks.md
@@ -1,0 +1,41 @@
+# Sinks
+
+A pipeline has one or more sinks. With more than one sink, Courier inserts an implicit broadcast splitter — every envelope is cloned to every sink, and the splitter is synchronous per sink (a slow sink applies backpressure to the whole pipeline). See [Backpressure](../concepts/backpressure.md).
+
+The simplest sink implements `WriteOne::write(&env)` and is wrapped in `ManagedSink`, which owns the recv loop, honors the `CancellationToken`, and applies the configured [`on_error`](../configuration/error-handling.md) and [retry](../configuration/error-handling.md#retry-on-sinks) policies.
+
+## `kafka`
+
+Produces records to a Kafka topic via `rdkafka`.
+
+```toml
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+on_error = "drop"
+
+[pipelines.sinks.retry]
+max_attempts = 5
+initial_delay_ms = 100
+backoff_multiplier = 2.0
+max_delay_ms = 5000
+
+[pipelines.sinks.retry.on_exhausted]
+kind = "propagate"
+```
+
+| Field     | Required | Description |
+| --------- | -------- | ----------- |
+| `brokers` | yes      | Comma-separated bootstrap broker list. |
+| `topic`   | yes      | Destination topic. |
+
+`meta.key` is used as the record key; `payload` is serialized as the record value.
+
+## Retry & dead-letter
+
+`on_error` and the `retry` block are extracted by the registry and wired into `ManagedSink` automatically — sink factories never parse those fields themselves. See [Error Handling & Retry](../configuration/error-handling.md) for the full schema.
+
+## Writing your own sink
+
+Implement `WriteOne` for the simple case — Courier wraps it in `ManagedSink` and you get retry, dead-letter, and `on_error` for free. For sinks that batch or maintain background connections, implement the full `Sink` trait directly. Register a `SinkFactory` against a unique `kind` — see [Contributing](../contributing.md).

--- a/docs/components/sources.md
+++ b/docs/components/sources.md
@@ -1,0 +1,45 @@
+# Sources
+
+A pipeline has exactly one source. Sources own their own cadence — they decide whether to poll, stream, or otherwise produce envelopes — and write them onto the pipeline's first mpsc channel.
+
+## `api_poll`
+
+Polls an HTTP endpoint on a fixed interval and emits the response body as an envelope payload.
+
+```toml
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+```
+
+| Field           | Required | Description |
+| --------------- | -------- | ----------- |
+| `url`           | yes      | The endpoint to poll. |
+| `interval_secs` | yes      | Seconds between successive polls. |
+
+The response body is parsed as JSON and used as `payload`. `meta.source_id` is set to the pipeline's source node id; `meta.timestamp_ms` is stamped at fetch time.
+
+## `kafka`
+
+Consumes from a Kafka topic via `rdkafka` and emits one envelope per record.
+
+```toml
+[pipelines.source]
+type = "kafka"
+brokers = "localhost:9092"
+group_id = "courier-quickstart"
+topics = ["topic1"]
+```
+
+| Field      | Required | Description |
+| ---------- | -------- | ----------- |
+| `brokers`  | yes      | Comma-separated bootstrap broker list. |
+| `group_id` | yes      | Consumer group id. |
+| `topics`   | yes      | List of topics to subscribe to. |
+
+Record key (when present) is copied to `meta.key`; Kafka topic, partition, and offset are copied to `meta.headers["kafka.topic"]`, `meta.headers["kafka.partition"]`, and `meta.headers["kafka.offset"]`; the record value is parsed as JSON into `payload`.
+
+## Writing your own source
+
+Implement `Source::run(tx, cancel)` and register a `SourceFactory` against a unique `kind`. See [Architecture](../concepts/architecture.md) and [Contributing](../contributing.md).

--- a/docs/components/transforms.md
+++ b/docs/components/transforms.md
@@ -1,0 +1,65 @@
+# Transforms
+
+Transforms operate on a stream of envelopes between the source and the sinks. They are ordered — `pipelines.transforms[0]` runs first.
+
+The simplest transform implements `MapOne::map(env) -> Option<Envelope>` (returning `None` filters the envelope out) and is wrapped in a `BasicTransform` that handles the recv loop, cancellation, and `on_error`. See [Architecture](../concepts/architecture.md#traits).
+
+## `set_key`
+
+Copies a payload field into `meta.key`. Useful for setting Kafka partition keys without writing a script.
+
+```toml
+[[pipelines.transforms]]
+type = "set_key"
+from_field = "userId"
+```
+
+| Field        | Required | Description |
+| ------------ | -------- | ----------- |
+| `from_field` | yes      | Top-level payload field whose value becomes `meta.key`. String values are copied as-is; other JSON values are stringified. |
+
+If the field is missing or the payload is not an object, the transform leaves `meta.key` unchanged. `on_error` only applies when the transform itself returns an error.
+
+## `script`
+
+Runs a user-provided script per envelope. Three runtimes are supported:
+
+| Runtime  | `runtime` value | Notes |
+| -------- | --------------- | ----- |
+| Rhai     | `"rhai"`        | Embedded sandboxed runtime, configurable execution budget. |
+| Lua      | `"lua"`         | Embedded via `mlua`. |
+| Python   | `"python"`      | Runs in a `python3` subprocess; not sandboxed. |
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "rhai"
+on_error = "drop"
+script = """
+fn transform(env) {
+  env.payload["processed"] = true;
+  env
+}
+"""
+```
+
+| Field                     | Required | Description |
+| ------------------------- | -------- | ----------- |
+| `runtime`                 | yes      | One of `"rhai"`, `"lua"`, `"python"`. |
+| `script`                  | one of   | Inline source code. Mutually exclusive with `script_file`. |
+| `script_file`             | one of   | Path to a script on disk. |
+| `entrypoint`              | no       | Function name to call. Defaults to `"transform"`. |
+| `python_bin`              | python   | Interpreter path. Defaults to `"python3"`. |
+| `max_operations`          | rhai     | Operation budget. Default `100000`. |
+| `max_call_levels`         | rhai     | Call stack depth. Default `32`. |
+| `max_expr_depth`          | rhai     | Expression nesting depth. Default `64`. |
+| `max_function_expr_depth` | rhai     | Per-function expression depth. Default `32`. |
+| `max_variables`           | rhai     | Max variables in scope. Default `64`. |
+
+Lua and Python reject the Rhai-only limit fields rather than silently ignoring them.
+
+See [Scripting](../scripting/index.md) for runtime-specific guides — including the exact `env` binding shape, return semantics, and per-runtime caveats.
+
+## Writing your own transform
+
+The simplest path is to implement `MapOne` and wrap it in `BasicTransform`. For stateful transforms (batching, flat-map, background work), implement the full `Transform` trait directly. Register a `TransformFactory` against a unique `kind` — see [Contributing](../contributing.md).

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,55 @@
+# Architecture
+
+A Courier **pipeline** is a directed acyclic graph:
+
+```text
+Source → Transform* → Sink[]
+```
+
+Each node runs as its own Tokio task and communicates with its neighbors through bounded `tokio::mpsc` channels. The runtime has no global scheduler — once `Courier::run()` spawns the tasks, flow control is governed entirely by channel capacity.
+
+## Core types
+
+| Type        | Lives in              | Role |
+| ----------- | --------------------- | ---- |
+| `Envelope`  | `src/envelope.rs`     | Single wire type between nodes — see [Envelope](envelope.md). |
+| `Pipeline`  | `src/pipeline.rs`     | One source, zero or more transforms, one or more sinks, plus a `channel_capacity`. |
+| `Courier`   | `src/lib.rs`          | Collection of pipelines. `run()` spawns the tasks and installs a SIGINT handler that fires a shared `CancellationToken`. |
+
+Generics stop at the node boundary. Strongly-typed payloads are opt-in: a transform can deserialize from `serde_json::Value`, do its work in a typed struct, and re-serialize on the way out.
+
+## Traits
+
+Each role has two traits — a **full-control** one that owns the channel loop, and an **ergonomic** one that handles a single item. The ergonomic side covers the common case; the full-control side is the escape hatch for stateful work like batching, flat-map, or background retry.
+
+| Role      | Full-control trait | Ergonomic trait | Wrapper |
+| --------- | ------------------ | ---------------- | ------- |
+| Source    | `Source`           | —                | — (sources drive their own cadence; poll vs stream doesn't factor out). |
+| Transform | `Transform`        | `MapOne`         | `BasicTransform` |
+| Sink      | `Sink`             | `WriteOne`       | `ManagedSink` |
+
+`MapOne::map(env) -> Result<Option<Envelope>>` makes filtering implicit — return `Ok(None)` to drop. `WriteOne::write(&env)` keeps sinks focused on the side effect.
+
+`BasicTransform` and `ManagedSink` own the recv loop, honor the `CancellationToken`, and apply the configured [`ErrorPolicy`](../configuration/error-handling.md). `ManagedSink` additionally drives the optional retry policy and the dead-letter destination.
+
+## Component registry
+
+`Registry` maps short `kind` strings (`"kafka"`, `"api_poll"`, `"script"`, …) to factories that build trait objects from a `serde_json::Value` spec. Each role has its own namespace, so `"kafka"` can be both a source and a sink without collision. Duplicate `kind`s within a role are rejected at registration time.
+
+The plugin model has three tiers:
+
+1. **Built-ins** — registered via `register_builtin(&mut registry)` (or `Registry::with_builtins()`).
+2. **Statically-linked plugin crates** — call the crate's own `register(&mut registry)` before building the `Courier`. This is the first-class native plugin mechanism today.
+3. **(Future) dynamic plugins** — the factory traits are object-safe, so `libloading` or scripting layers are additive.
+
+`Registry::build_courier(config)` mints hierarchical node ids of the form `{pipeline}/src`, `{pipeline}/t{i}`, `{pipeline}/sink{i}` so log lines and metrics trace back to the owning pipeline. Sink factories that wrap a `WriteOne` in `ManagedSink` receive `on_error` and `retry` pre-extracted by the registry — they never parse those fields themselves.
+
+## Runtime
+
+`spawn_pipeline` (in `src/pipeline.rs`) wires `source → transforms → sinks` with bounded mpsc channels. When `sinks.len() > 1`, an implicit broadcast splitter is inserted that clones each envelope to every sink. The splitter is synchronous per sink — a slow sink applies backpressure to the whole pipeline by design. See [Backpressure](backpressure.md).
+
+`Courier::run()`:
+
+1. Spawns each stage of each pipeline as a Tokio task.
+2. Installs a SIGINT/Ctrl+C handler that fires the shared `CancellationToken`.
+3. Awaits graceful drain.

--- a/docs/concepts/backpressure.md
+++ b/docs/concepts/backpressure.md
@@ -1,0 +1,44 @@
+# Backpressure
+
+Courier does not have a global rate limiter or scheduler. End-to-end flow control comes entirely from the bounded `tokio::mpsc` channels between nodes.
+
+## How it works
+
+Every edge in a pipeline is an mpsc channel with a buffer of `channel_capacity` envelopes. The channel's `send` future completes only when there is room in the buffer.
+
+That gives natural propagation: when a sink slows down, its inbox fills, the upstream transform's `send` blocks, *its* inbox fills, and eventually the source stops pulling. There is no back-channel "please slow down" message — the absence of buffer space is the signal.
+
+```text
+Source ──[64 buffered]──> Transform ──[64 buffered]──> Sink
+                                                        ▲
+                                                slow consumer
+                                                pauses here
+```
+
+## The broadcast splitter
+
+When a pipeline has more than one sink, Courier inserts an implicit broadcast splitter that clones each envelope to every sink. **The splitter is synchronous per sink**: it sends to every downstream channel in turn and only moves on once they have all accepted. That means a slow sink applies backpressure to the whole pipeline.
+
+This is a deliberate design choice. It keeps semantics simple — every sink sees every envelope, in order — at the cost of pinning throughput to the slowest consumer. If you need an independent slow consumer, run it in its own pipeline reading from the same source.
+
+## Tuning `channel_capacity`
+
+`channel_capacity` is a per-pipeline knob set in the pipeline's top-level config:
+
+```toml
+[[pipelines]]
+name = "api->kafka"
+channel_capacity = 64
+```
+
+- **Smaller** values (e.g. 1–16) tighten backpressure: producers feel slowdowns sooner, latency stays predictable, memory bounded. Good for low-volume control planes.
+- **Larger** values (e.g. 256–4096) let bursts pass through without stalling the source. Good for ingestion pipelines where short consumer hiccups are common and average throughput is what matters.
+
+There is no one-size-fits-all default — pick a value that matches the burst profile of your source and the latency characteristics of your sink. A safe starting point for most workloads is somewhere in the 32–128 range, then adjust based on the queue depth you observe in the logs.
+
+## Cancellation vs backpressure
+
+Backpressure pauses *production*; cancellation stops the pipeline. Both are wired through Tokio primitives but they are separate concerns:
+
+- A full inbox is normal — wait for it to drain.
+- A fired `CancellationToken` (SIGINT, or `on_error = "fail_pipeline"`) tells every node to finish its current item and exit.

--- a/docs/concepts/envelope.md
+++ b/docs/concepts/envelope.md
@@ -1,0 +1,29 @@
+# Envelope
+
+The `Envelope` is the single message type that flows between every Courier node. It lives in `src/envelope.rs` and is a small, deliberately generic shape:
+
+```text
+Envelope
+├── meta: Meta
+│   ├── key: Option<String>
+│   ├── source_id: String
+│   ├── timestamp_ms: i64
+│   └── headers: HashMap<String, String>
+└── payload: serde_json::Value
+```
+
+Keeping a single type at the boundary lets the runtime stay generic-free at the channel layer. The trade-off is that strongly-typed payloads are opt-in — a transform that wants typed data deserializes the `payload` into a struct, operates on it, and re-serializes on the way out.
+
+## Field roles
+
+| Field            | Role |
+| ---------------- | ---- |
+| `meta.key`       | Logical partitioning key — used by sinks like Kafka to choose the destination partition. The built-in [`set_key`](../components/transforms.md#set_key) transform sets this from a payload field. |
+| `meta.source_id` | Hierarchical id of the producing node, e.g. `pipeline-name/src`. Useful for observability and for transforms that want to behave differently per source. |
+| `meta.timestamp_ms` | Producer-assigned timestamp. Sources stamp it; transforms can overwrite. |
+| `meta.headers`   | Free-form string headers. Conventionally used for routing hints and metadata that should not live in the payload. |
+| `payload`        | Arbitrary JSON. Most transforms operate here. |
+
+## Scripted access
+
+Script transforms expose the same shape under whichever runtime is running. See [Scripting](../scripting/index.md) for the full table of binding shapes per runtime.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,11 @@
+---
+icon: lucide/network
+---
+
+# Concepts
+
+These pages give you the mental model behind Courier's runtime. They are short by design — read them before writing your own components.
+
+- **[Architecture](architecture.md)** — how a pipeline is wired up, the role of each trait, and how the registry resolves component kinds.
+- **[Envelope](envelope.md)** — the single message type that flows between every node.
+- **[Backpressure](backpressure.md)** — how bounded channels and the broadcast splitter shape end-to-end flow control.

--- a/docs/configuration/error-handling.md
+++ b/docs/configuration/error-handling.md
@@ -1,0 +1,94 @@
+# Error handling & retry
+
+Transforms and sinks can independently configure how they react to failures. Sinks additionally support automatic retry with a configurable backoff and dead-letter routing.
+
+## `on_error` — the error policy
+
+Every transform and sink accepts an optional `on_error` field:
+
+| Value           | Behavior |
+| --------------- | -------- |
+| `drop`          | Log the error and continue. The envelope is dropped. |
+| `fail_pipeline` | Cancel the entire pipeline via its `CancellationToken`. Other pipelines in the same `Courier` keep running. |
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "rhai"
+on_error = "drop"
+script = "fn transform(env) { env }"
+```
+
+If `on_error` is omitted the implementation default is used (typically `drop`).
+
+## Retry on sinks
+
+Sinks built on top of `ManagedSink` accept an optional retry policy. Retry runs *before* `on_error`: if all attempts fail, the policy's `on_exhausted` action decides whether to propagate the error (and let `on_error` handle it) or to dead-letter the envelope.
+
+```toml
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+on_error = "drop"
+
+[pipelines.sinks.retry]
+max_attempts = 5
+initial_delay_ms = 100
+backoff_multiplier = 2.0
+max_delay_ms = 5000
+
+[pipelines.sinks.retry.on_exhausted]
+kind = "propagate"
+```
+
+| Field                | Description |
+| -------------------- | ----------- |
+| `max_attempts`       | Maximum attempts including the first try. |
+| `initial_delay_ms`   | Delay before the second attempt. |
+| `backoff_multiplier` | Backoff multiplier applied after each failure. |
+| `max_delay_ms`       | Cap on the delay between attempts. |
+| `on_exhausted`       | What to do once `max_attempts` is reached. See below. |
+
+## Exhausted policy
+
+Once retries are exhausted, `on_exhausted` decides the fate of the envelope:
+
+=== "Propagate"
+
+    ```toml
+    [pipelines.sinks.retry]
+    max_attempts = 3
+    initial_delay_ms = 100
+    backoff_multiplier = 2.0
+    max_delay_ms = 5000
+
+    [pipelines.sinks.retry.on_exhausted]
+    kind = "propagate"
+    ```
+
+    The last error is returned to `ManagedSink`, which then applies `on_error`. With `on_error = "drop"`, the envelope is logged and dropped; with `fail_pipeline`, the whole pipeline is cancelled.
+
+=== "Dead-letter"
+
+    ```toml
+    [pipelines.sinks.retry]
+    max_attempts = 3
+    initial_delay_ms = 100
+    backoff_multiplier = 2.0
+    max_delay_ms = 5000
+
+    [pipelines.sinks.retry.on_exhausted]
+    kind = "dead_letter"
+    path = "./dlq.jsonl"
+    ```
+
+    The failed envelope is appended to `path` as a single JSON line, then the pipeline continues. If the dead-letter write itself fails, the original error is propagated as if `kind = "propagate"` had been configured.
+
+The dead-letter file format is one JSON envelope per line; treat it as provisional until Courier reaches 1.0.
+
+## Choosing a strategy
+
+- For idempotent sinks, prefer `dead_letter` with a generous `max_attempts` — transient blips will retry, and persistent failures land in a file you can inspect or replay.
+- For pipelines where any data loss is unacceptable, set `on_error = "fail_pipeline"` and let your supervisor (systemd, Kubernetes, etc.) restart the binary.
+- For transforms where the failure mode is "this one envelope is malformed", `on_error = "drop"` is usually right.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,39 @@
+---
+icon: lucide/settings
+---
+
+# Configuration
+
+Courier loads its pipeline definitions at runtime from a configuration file — there is no need to recompile when topology changes. The config file path defaults to `config.toml` in the working directory and can be overridden with the `COURIER_CONFIG` environment variable.
+
+`COURIER_CONFIG` may point at:
+
+- a single `.toml` or `.json` file, or
+- a directory — every `.toml`/`.json` file inside it is parsed in sorted order, and their `pipelines` lists are concatenated. Duplicate pipeline names across files are rejected at load time.
+
+Bad configuration fails at startup with a path-annotated error.
+
+## In this section
+
+- **[Pipelines](pipelines.md)** — the configuration schema for sources, transforms, sinks, and channels.
+- **[Error Handling & Retry](error-handling.md)** — `on_error`, retry policies, and dead-letter routing.
+
+## Minimal example
+
+```toml title="config.toml"
+[[pipelines]]
+name = "api->kafka"
+channel_capacity = 64
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+```
+
+See [Pipelines](pipelines.md) for the full set of fields.

--- a/docs/configuration/pipelines.md
+++ b/docs/configuration/pipelines.md
@@ -1,0 +1,90 @@
+# Pipeline configuration
+
+A configuration file declares a list of pipelines. Each pipeline has exactly one **source**, zero or more **transforms** in order, and one or more **sinks**.
+
+## Top-level shape
+
+```toml
+[[pipelines]]
+name = "api->kafka"          # required, must be unique across the whole config
+channel_capacity = 64        # optional, default applied per edge
+
+[pipelines.source]           # required, exactly one
+type = "api_poll"
+# ...source-specific fields
+
+[[pipelines.transforms]]     # optional, ordered
+type = "set_key"
+# ...transform-specific fields
+
+[[pipelines.sinks]]          # required, at least one
+type = "kafka"
+# ...sink-specific fields
+```
+
+| Field              | Required | Description |
+| ------------------ | -------- | ----------- |
+| `name`             | yes      | Unique identifier; appears in log/metric node ids. |
+| `channel_capacity` | no       | Buffer size for each `tokio::mpsc` edge inside the pipeline. Smaller values tighten [backpressure](../concepts/backpressure.md). |
+| `source`           | yes      | Exactly one source. See [Sources](../components/sources.md). |
+| `transforms`       | no       | Ordered list of transforms. See [Transforms](../components/transforms.md). |
+| `sinks`            | yes      | One or more sinks. With more than one, Courier inserts a broadcast splitter — every envelope is cloned to every sink, and a slow sink applies backpressure to the whole pipeline. |
+
+## Component shape
+
+Every source, transform, and sink shares this shape:
+
+```toml
+type = "<kind>"              # required — looked up in the component registry
+on_error = "drop"            # optional, transforms and sinks only — see error handling
+# (sinks only) optional retry table
+[<component>.retry]
+max_attempts = 5
+initial_delay_ms = 100
+backoff_multiplier = 2.0
+max_delay_ms = 5000
+
+[<component>.retry.on_exhausted]
+kind = "propagate"           # or "dead_letter" with a `path`
+
+# any remaining fields are passed to the component-specific factory
+```
+
+The `type` field is matched against the registered `kind` in the [component registry](../concepts/architecture.md#component-registry). Each category (source / transform / sink) has its own namespace, so `"kafka"` can be both a source and a sink without collision.
+
+## Multiple files (directory mode)
+
+When `COURIER_CONFIG` points at a directory, Courier reads every `.toml`/`.json` file in sorted order and concatenates their `pipelines` lists. This makes it straightforward to keep one pipeline per file:
+
+```text
+pipelines.d/
+├── 10-orders.toml
+├── 20-events.toml
+└── 90-debug.json
+```
+
+Duplicate pipeline names across files are rejected at load time.
+
+## JSON form
+
+The same schema works in JSON. TOML datetimes are stringified internally so the two formats accept the same component fields:
+
+```json title="pipelines.d/10-orders.json"
+{
+  "pipelines": [
+    {
+      "name": "api->kafka",
+      "source": {
+        "type": "api_poll",
+        "url": "https://jsonplaceholder.typicode.com/posts/1",
+        "interval_secs": 3
+      },
+      "sinks": [
+        { "type": "kafka", "brokers": "localhost:9092", "topic": "topic1" }
+      ]
+    }
+  ]
+}
+```
+
+Continue to [Error Handling & Retry](error-handling.md) for `on_error` and retry semantics.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,116 @@
+---
+icon: lucide/heart-handshake
+---
+
+# Contributing
+
+Courier is pre-1.0 and welcomes contributions — bug reports, design feedback, and pull requests. This page covers the local development workflow and the docs site itself.
+
+## Development workflow
+
+Standard cargo commands:
+
+```bash
+cargo build                          # build
+cargo check                          # fast type/borrow check
+cargo clippy --all-targets           # lint
+cargo fmt                            # format
+cargo test                           # run all tests
+cargo test <test_name>               # run a single test
+```
+
+CI runs `clippy` and `cargo test` on every push. Please run them locally before opening a pull request.
+
+## Project layout
+
+A short tour of the `src/` tree:
+
+| Path                    | Role |
+| ----------------------- | ---- |
+| `src/lib.rs`            | `Courier` — top-level runtime, SIGINT handling. |
+| `src/pipeline.rs`       | `Pipeline`, `spawn_pipeline`, broadcast splitter. |
+| `src/envelope.rs`       | `Envelope` and `Meta`. |
+| `src/sources/`          | `Source` trait and built-ins. |
+| `src/transforms/`       | `Transform`, `MapOne`, `BasicTransform`, built-ins. |
+| `src/sinks/`            | `Sink`, `WriteOne`, `ManagedSink`, built-ins. |
+| `src/retry.rs`          | `RetryPolicy`, `ExhaustedPolicy`, dead-letter writer. |
+| `src/registry.rs`       | `Registry` — kind → factory mapping. |
+| `src/config.rs`         | TOML/JSON loaders and `parse_config`. |
+| `src/main.rs`           | Binary entry point. Reads `COURIER_CONFIG`, builds a default registry, runs. |
+
+## Writing a new component
+
+The fastest path is to implement the **ergonomic** trait for the role and let Courier's wrappers handle the channel loop, cancellation, and policies:
+
+- **Transform** → implement `MapOne`, wrap in `BasicTransform`.
+- **Sink** → implement `WriteOne`, wrap in `ManagedSink` (you get retry, dead-letter, and `on_error` for free).
+- **Source** → implement `Source::run(tx, cancel)` directly. Sources own their own cadence.
+
+Then register a factory against a unique `kind` string. Use `courier::config::parse_config` inside the factory so config errors get a uniform `"invalid config for component type '{kind}'"` message.
+
+## Plugin crates
+
+External components live in their own crate and expose a single `register(&mut Registry)` function. Call it before building the `Courier`:
+
+```rust
+let mut registry = Registry::with_builtins();
+my_plugin::register(&mut registry);
+let courier = registry.build_courier(config)?;
+```
+
+The factory traits are object-safe, so dynamic loading (`libloading`, scripting layers) is additive — it does not require API changes.
+
+## Documentation site
+
+The documentation site lives in `docs/` and is built with [Zensical](https://zensical.org).
+
+### Local preview
+
+The simplest way to run Zensical locally is through [`uv`](https://docs.astral.sh/uv/) — no global install, no virtualenv to manage:
+
+```bash
+uvx zensical serve         # live-reload preview at http://127.0.0.1:8000
+uvx zensical build --clean # static build into ./site
+```
+
+!!! note "Template overrides leak into `site/`"
+    `docs/overrides/` holds Jinja template overrides used by the home hero.
+    Zensical copies every non-Markdown file under `docs/` verbatim into the
+    output, so a stray `site/overrides/home.html` ends up in the build. It is
+    harmless (no link or sitemap entry points to it), but the CI workflow
+    strips it before deploy. Run `rm -rf site/overrides` after a local build
+    if you want to mirror that behavior.
+
+If you prefer a regular install:
+
+```bash
+pip install zensical
+zensical serve
+```
+
+`zensical.toml` at the repo root is the source of truth for site name, navigation, theme, and Markdown extensions.
+
+### Adding a page
+
+1. Create the Markdown file under `docs/` — typically inside an existing section directory.
+2. Add it to the `nav` array in `zensical.toml`. Keep the order intentional; the sidebar mirrors `nav` exactly.
+3. Run `zensical serve` and verify the page renders, the sidebar entry shows up, and any cross-links resolve.
+
+### Style
+
+- Lead each page with a one-paragraph summary of what the page covers.
+- Prefer tables over prose for reference material (config fields, traits, runtimes).
+- Cross-link liberally — `[Architecture](concepts/architecture.md)` is more discoverable than "see the architecture page".
+- Keep code examples minimal and copy-pasteable.
+
+### Deployment
+
+The `Documentation` GitHub Actions workflow (`.github/workflows/docs.yml`) builds the site on every push to `main` and publishes to GitHub Pages.
+
+## Reporting bugs
+
+Open an issue on GitHub with:
+
+- The `config.toml` (or relevant pipeline excerpt) that reproduces the problem.
+- The Courier git SHA you are running.
+- Any logs from `RUST_LOG=courier=debug` if the failure is at runtime.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,177 @@
+---
+icon: lucide/book-open
+---
+
+# Examples
+
+End-to-end pipeline recipes. Drop them into a `config.toml` and run `cargo run` — no recompile required between edits.
+
+## API → Kafka
+
+The simplest useful pipeline. Polls an HTTP endpoint and forwards the response to a Kafka topic.
+
+```toml
+[[pipelines]]
+name = "api->kafka"
+channel_capacity = 64
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+```
+
+## API → Kafka, with a partition key
+
+Use the [`set_key`](components/transforms.md#set_key) transform to partition records by a payload field.
+
+```toml
+[[pipelines]]
+name = "api->kafka-keyed"
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.transforms]]
+type = "set_key"
+from_field = "userId"
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+```
+
+## API → Kafka, with a Rhai transform
+
+Tag envelopes from a specific user as high-priority.
+
+```toml
+[[pipelines]]
+name = "api->kafka-rhai"
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.transforms]]
+type = "script"
+runtime = "rhai"
+on_error = "drop"
+script = """
+fn transform(env) {
+  if env.payload["userId"] == 1 {
+    env.meta.headers["priority"] = "high";
+  }
+
+  env.payload["processed"] = true;
+  env
+}
+"""
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+```
+
+## Fan-out to multiple sinks
+
+When you list more than one sink, Courier inserts an implicit broadcast splitter that clones each envelope to every sink. The splitter is synchronous per sink — see [Backpressure](concepts/backpressure.md).
+
+```toml
+[[pipelines]]
+name = "api->fanout"
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1-mirror"
+```
+
+## Sink with retry and dead-letter
+
+Retry transient failures with exponential backoff; persist exhausted envelopes to a JSON-lines file.
+
+```toml
+[[pipelines]]
+name = "api->kafka-retry"
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+on_error = "drop"
+
+[pipelines.sinks.retry]
+max_attempts = 5
+initial_delay_ms = 100
+backoff_multiplier = 2.0
+max_delay_ms = 5000
+
+[pipelines.sinks.retry.on_exhausted]
+kind = "dead_letter"
+path = "./dlq.jsonl"
+```
+
+## Lua transform from a file
+
+Keep the script in version-controlled source instead of inline TOML:
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "lua"
+script_file = "./transforms/enrich.lua"
+```
+
+```lua title="transforms/enrich.lua"
+function transform(env)
+  env.payload.processed = true
+  return env
+end
+```
+
+## Python transform with a virtualenv
+
+Point `python_bin` at a virtualenv if your script needs third-party packages.
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "python"
+script_file = "./transforms/enrich.py"
+python_bin = "./.venv/bin/python"
+```
+
+```python title="transforms/enrich.py"
+import sys
+
+def transform(env):
+    print(f"processing key={env['meta']['key']}", file=sys.stderr)
+    env["payload"]["processed"] = True
+    return env
+```

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,12 @@
+---
+icon: lucide/play
+---
+
+# Getting Started
+
+This section walks you through installing Courier and getting a pipeline running end-to-end.
+
+- **[Installation](installation.md)** — toolchain prerequisites and how to build the binary.
+- **[Quickstart](quickstart.md)** — write a minimal `config.toml` and run your first pipeline.
+
+If you are new to Courier, start with the [Architecture](../concepts/architecture.md) page in *Concepts* for a one-page mental model of how the runtime is wired up.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,41 @@
+# Installation
+
+## Prerequisites
+
+- A recent stable Rust toolchain — install via [rustup](https://rustup.rs/).
+- A C toolchain (Courier links against `rdkafka` for the Kafka source/sink).
+- Optional, for the [Python script transform](../scripting/python.md): a `python3` interpreter reachable on `PATH` or via the `python_bin` config field.
+
+## Build from source
+
+Courier currently ships as a binary built from source.
+
+```bash
+git clone https://github.com/gbPagano/courier
+cd courier
+cargo build --release
+```
+
+The release binary is produced at `target/release/courier`.
+
+## Verify the build
+
+A debug build is enough for local development:
+
+```bash
+cargo check          # fast type/borrow check
+cargo test           # run the test suite
+cargo clippy --all-targets
+```
+
+## Run with a config
+
+By default, Courier reads `config.toml` from the working directory. Override the path with the `COURIER_CONFIG` environment variable — it can point at a single `.toml`/`.json` file or at a directory containing several:
+
+```bash
+COURIER_CONFIG=./pipelines.d cargo run
+```
+
+In directory mode, every `.toml`/`.json` file in the directory is parsed in sorted order and the resulting `pipelines` lists are concatenated.
+
+Continue to the [Quickstart](quickstart.md) for a runnable minimal config.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart
+
+This page walks you through a minimal pipeline that polls a public HTTP endpoint and writes each response to a Kafka topic.
+
+## 1. Bring up Kafka
+
+Any local Kafka broker on `localhost:9092` works. The fastest path is the official Docker Compose recipe published by Confluent or Bitnami; pick one and ensure a topic named `topic1` exists.
+
+## 2. Write a `config.toml`
+
+Create the file at the repository root:
+
+```toml title="config.toml"
+[[pipelines]]
+name = "api->kafka"
+channel_capacity = 64
+
+[pipelines.source]
+type = "api_poll"
+url = "https://jsonplaceholder.typicode.com/posts/1"
+interval_secs = 3
+
+[[pipelines.sinks]]
+type = "kafka"
+brokers = "localhost:9092"
+topic = "topic1"
+```
+
+A few things to notice:
+
+- `channel_capacity` is the buffer size for every mpsc edge in the pipeline. Smaller numbers tighten [backpressure](../concepts/backpressure.md).
+- `pipelines.sinks` is a list — Courier inserts a broadcast splitter automatically when there is more than one sink.
+- `type = "api_poll"` and `type = "kafka"` resolve to built-in factories from the [component registry](../concepts/architecture.md#component-registry).
+
+## 3. Run
+
+```bash
+cargo run
+```
+
+You should see structured logs as each poll cycle pushes an envelope through the pipeline. Press <kbd>Ctrl</kbd>+<kbd>C</kbd> — Courier installs a SIGINT handler that drains gracefully via a shared `CancellationToken`.
+
+## 4. Add a transform
+
+Add a [scripted transform](../scripting/index.md) between the source and the sink to attach a header:
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "rhai"
+script = """
+fn transform(env) {
+  env.meta.headers["source"] = "quickstart";
+  env
+}
+"""
+```
+
+Restart the binary — there is no compile step.
+
+## Next steps
+
+- [Configuration](../configuration/index.md) — full schema for pipelines, error policies, and retry.
+- [Components](../components/index.md) — reference for every built-in source, transform, and sink.
+- [Examples](../examples.md) — end-to-end recipes covering more topologies.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+---
+template: home.html
+title: Courier — async Rust pipelines
+hide:
+  - navigation
+  - toc
+---
+
+## What it does
+
+- Build pipelines declaratively from a TOML or JSON config file
+- Connect sources, transforms, and sinks through bounded channels
+- Fan out automatically to multiple sinks with a built-in broadcast splitter
+- Apply [backpressure](concepts/backpressure.md) end-to-end through bounded channels
+- Retry failed sink writes with exponential backoff and a dead-letter destination
+- Embed scripted [transforms](scripting/index.md) in Rhai, Lua, or Python
+- Shut down gracefully on SIGINT via a shared `CancellationToken`
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+- :material-clock-fast: **[Getting Started](getting-started/index.md)** — install Courier and run your first pipeline.
+- :material-cog: **[Configuration](configuration/index.md)** — write `config.toml` files and tune error handling.
+- :material-graph-outline: **[Concepts](concepts/index.md)** — understand the runtime, the envelope, and backpressure.
+- :material-puzzle: **[Components](components/index.md)** — reference for built-in sources, transforms, and sinks.
+- :material-script-text: **[Scripting](scripting/index.md)** — write transforms in Rhai, Lua, or Python.
+- :material-book-open-page-variant: **[Examples](examples.md)** — end-to-end pipeline recipes.
+
+</div>
+
+## Project status
+
+Courier is pre-1.0. Treat the public API, configuration schema, and on-disk formats (including the dead-letter file format) as provisional. Breaking changes will be called out in the [contributing guide](contributing.md) and release notes.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block hero %}
+  <section class="cx-hero">
+    <div class="cx-hero__inner md-grid">
+      <div class="cx-hero__content">
+        <p class="cx-hero__eyebrow">
+          <span class="cx-hero__badge">pre-1.0 · provisional API</span>
+        </p>
+        <h1 class="cx-hero__title">Courier</h1>
+        <p class="cx-hero__subtitle">
+          Async Rust framework for composable data pipelines.
+          <br>
+          <code>Source &rarr; Transform* &rarr; Sink[]</code>, declared in TOML, wired at runtime.
+        </p>
+        <div class="cx-hero__actions">
+          <a href="getting-started/installation/" class="md-button md-button--primary cx-hero__cta">
+            Get started
+          </a>
+          <a href="https://github.com/gbPagano/courier" class="md-button cx-hero__cta">
+            View on GitHub
+          </a>
+        </div>
+      </div>
+      <div class="cx-hero__preview" aria-hidden="true">
+<pre><code><span class="cx-tok-key">[[pipelines]]</span>
+<span class="cx-tok-attr">name</span> = <span class="cx-tok-str">"api-&gt;kafka"</span>
+
+<span class="cx-tok-key">[pipelines.source]</span>
+<span class="cx-tok-attr">type</span>          = <span class="cx-tok-str">"api_poll"</span>
+<span class="cx-tok-attr">url</span>           = <span class="cx-tok-str">"https://api.example.com/v1/events"</span>
+<span class="cx-tok-attr">interval_secs</span> = <span class="cx-tok-num">3</span>
+
+<span class="cx-tok-key">[[pipelines.transforms]]</span>
+<span class="cx-tok-attr">type</span>    = <span class="cx-tok-str">"script"</span>
+<span class="cx-tok-attr">runtime</span> = <span class="cx-tok-str">"rhai"</span>
+<span class="cx-tok-attr">script</span>  = <span class="cx-tok-str">"""</span>
+<span class="cx-tok-str">  fn transform(env) {</span>
+<span class="cx-tok-str">    env.payload["seen"] = true;</span>
+<span class="cx-tok-str">    env</span>
+<span class="cx-tok-str">  }</span>
+<span class="cx-tok-str">"""</span>
+
+<span class="cx-tok-key">[[pipelines.sinks]]</span>
+<span class="cx-tok-attr">type</span>    = <span class="cx-tok-str">"kafka"</span>
+<span class="cx-tok-attr">brokers</span> = <span class="cx-tok-str">"localhost:9092"</span>
+<span class="cx-tok-attr">topic</span>   = <span class="cx-tok-str">"events"</span>
+</code></pre>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/docs/scripting/index.md
+++ b/docs/scripting/index.md
@@ -1,0 +1,59 @@
+---
+icon: lucide/code
+---
+
+# Scripting
+
+The built-in `script` transform lets you write per-envelope logic without recompiling Courier. Three runtimes ship out of the box:
+
+- **[Rhai](rhai.md)** — small, sandboxed embedded runtime with a configurable execution budget. Best default for short, untrusted-ish snippets.
+- **[Lua](lua.md)** — embedded via `mlua`. Familiar syntax, no subprocess overhead.
+- **[Python](python.md)** — runs in a `python3` subprocess. Not sandboxed; unlocks the full Python ecosystem at the cost of process boundary overhead.
+
+## Choosing a runtime
+
+| Concern                          | Rhai | Lua | Python |
+| -------------------------------- | :--: | :-: | :----: |
+| Embedded (no subprocess)         | ✅   | ✅  | ❌     |
+| Sandbox / execution budget       | ✅   | ❌  | ❌     |
+| External libraries available     | ❌   | ❌  | ✅     |
+| Cold-start cost                  | low  | low | higher |
+
+When in doubt, start with Rhai. Move to Lua for slightly more familiar syntax. Reach for Python when you need libraries Courier can't reasonably ship (e.g. heavy data manipulation, ML inference).
+
+## Common shape
+
+All three runtimes share the same component config — just the `runtime` field changes. Common fields:
+
+| Field         | Description |
+| ------------- | ----------- |
+| `runtime`     | One of `"rhai"`, `"lua"`, `"python"`. |
+| `script`      | Inline source. Mutually exclusive with `script_file`. |
+| `script_file` | Path to a script on disk. |
+| `entrypoint`  | Function name to call. Defaults to `"transform"`. |
+
+Runtime-specific fields (Rhai limit knobs, `python_bin`) are documented on each runtime's page.
+
+## The `env` binding
+
+Each runtime exposes the [Envelope](../concepts/envelope.md) under a binding called `env`. Field access syntax differs slightly per runtime:
+
+| Field                    | Rhai / Lua                | Python                     |
+| ------------------------ | ------------------------- | -------------------------- |
+| Logical key              | `env.meta.key`            | `env["meta"]["key"]`       |
+| Source node id           | `env.meta.source_id`      | `env["meta"]["source_id"]` |
+| Producer timestamp (ms)  | `env.meta.timestamp_ms`   | `env["meta"]["timestamp_ms"]` |
+| Headers map              | `env.meta.headers`        | `env["meta"]["headers"]`   |
+| Payload                  | `env.payload`             | `env["payload"]`           |
+
+## Return semantics
+
+Each runtime maps a "drop this envelope" outcome to its idiomatic empty value:
+
+| Runtime | Emit transformed envelope | Filter envelope out |
+| ------- | ------------------------- | ------------------- |
+| Rhai    | `return env`              | `return ()`         |
+| Lua     | `return env`              | `return nil`        |
+| Python  | `return env`              | `return None`       |
+
+Runtime errors (parse failures, exceptions, budget exhaustion, subprocess crashes) follow the transform's `on_error` policy. See [Error handling](../configuration/error-handling.md).

--- a/docs/scripting/lua.md
+++ b/docs/scripting/lua.md
@@ -1,0 +1,61 @@
+# Lua
+
+The Lua runtime is embedded in-process via [`mlua`](https://github.com/mlua-rs/mlua). Use it when you want familiar Lua syntax for small transforms.
+
+## Minimal example
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "lua"
+on_error = "drop"
+script = """
+function transform(env)
+  if env.payload.userId == 1 then
+    env.meta.headers.priority = "high"
+  end
+
+  env.payload.processed = true
+  return env
+end
+"""
+```
+
+## `script_file`
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "lua"
+script_file = "./transforms/enrich.lua"
+```
+
+```lua title="transforms/enrich.lua"
+function transform(env)
+  env.payload.processed = true
+  return env
+end
+```
+
+`script` and `script_file` are mutually exclusive — set exactly one.
+
+## Return semantics
+
+- `return env` — emit the (possibly mutated) envelope downstream.
+- `return nil` (or no `return`) — filter the envelope out.
+
+## Limits
+
+The Lua runtime does not expose an execution budget today. The Rhai-only limit fields (`max_operations`, `max_call_levels`, etc.) are **rejected** at config-load time when `runtime = "lua"` — the transform fails to register rather than silently ignoring them.
+
+## `env` binding
+
+| Field                    | Access                  |
+| ------------------------ | ----------------------- |
+| Logical key              | `env.meta.key`          |
+| Source node id           | `env.meta.source_id`    |
+| Producer timestamp (ms)  | `env.meta.timestamp_ms` |
+| Headers map              | `env.meta.headers`      |
+| Payload                  | `env.payload`           |
+
+`env.payload` is exposed as a Lua table mirroring the JSON structure.

--- a/docs/scripting/python.md
+++ b/docs/scripting/python.md
@@ -1,0 +1,81 @@
+# Python
+
+The Python runtime runs your script in a `python3` subprocess and communicates over a small worker protocol on stdin/stdout. Use it when you need access to the Python ecosystem from a transform.
+
+!!! warning "Caveats"
+
+    - **Not sandboxed.** A Python script can do anything `python3` can do on the host.
+    - **Not managed.** Courier does not create virtualenvs or install packages — that is your responsibility.
+    - **stdout is reserved.** The worker protocol uses stdout. Send logs to **stderr** (e.g. `print(..., file=sys.stderr)`).
+
+## Minimal example
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "python"
+on_error = "drop"
+script = """
+def transform(env):
+  if env["payload"]["userId"] == 1:
+    env["meta"]["headers"]["priority"] = "high"
+
+  env["payload"]["processed"] = True
+  return env
+"""
+```
+
+## `script_file`
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "python"
+script_file = "./transforms/enrich.py"
+python_bin = "python3"
+```
+
+```python title="transforms/enrich.py"
+def transform(env):
+    env["payload"]["processed"] = True
+    return env
+```
+
+`script` and `script_file` are mutually exclusive — set exactly one.
+
+## Choosing the interpreter
+
+By default the runtime invokes `python3` from `PATH`. Override with `python_bin`:
+
+```toml
+python_bin = "/opt/python3.12/bin/python3"
+```
+
+This is the canonical way to point at a virtualenv:
+
+```toml
+python_bin = "./.venv/bin/python"
+```
+
+## Return semantics
+
+- `return env` — emit the (possibly mutated) envelope downstream.
+- `return None` (or no `return`) — filter the envelope out.
+
+A subprocess crash, an uncaught exception, or a stdout/stderr protocol violation is reported as a runtime error and follows the transform's `on_error` policy.
+
+## Limits
+
+The Python runtime does not expose an execution budget. The Rhai-only limit fields are **rejected** at config-load time when `runtime = "python"`.
+
+## `env` binding
+
+The same envelope shape, exposed as a plain Python dict:
+
+| Field                    | Access                          |
+| ------------------------ | ------------------------------- |
+| Logical key              | `env["meta"]["key"]`            |
+| Source node id           | `env["meta"]["source_id"]`      |
+| Producer timestamp (ms)  | `env["meta"]["timestamp_ms"]`   |
+| Headers map              | `env["meta"]["headers"]`        |
+| Payload                  | `env["payload"]`                |

--- a/docs/scripting/rhai.md
+++ b/docs/scripting/rhai.md
@@ -1,0 +1,68 @@
+# Rhai
+
+[Rhai](https://rhai.rs) is a small embedded scripting language for Rust. It runs in-process, supports a configurable execution budget, and is the default choice for short transforms.
+
+## Minimal example
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "rhai"
+on_error = "drop"
+script = """
+fn transform(env) {
+  if env.payload["userId"] == 1 {
+    env.meta.headers["priority"] = "high";
+  }
+
+  env.payload["processed"] = true;
+  env
+}
+"""
+```
+
+## `script_file`
+
+Load the script from disk instead of inlining it:
+
+```toml
+[[pipelines.transforms]]
+type = "script"
+runtime = "rhai"
+script_file = "./transforms/enrich.rhai"
+```
+
+`script` and `script_file` are mutually exclusive — set exactly one.
+
+## Return semantics
+
+- `return env` — emit the (possibly mutated) envelope downstream.
+- `return ()` (or no return value) — filter the envelope out.
+
+## Execution limits
+
+Rhai exposes a number of safety knobs. All are optional and have sensible defaults:
+
+| Field                     | Default  | Purpose |
+| ------------------------- | -------- | ------- |
+| `max_operations`          | `100000` | Operation budget per call. Prevents infinite loops. |
+| `max_call_levels`         | `32`     | Max function call depth. |
+| `max_expr_depth`          | `64`     | Max expression nesting in top-level scope. |
+| `max_function_expr_depth` | `32`     | Max expression nesting inside function bodies. |
+| `max_variables`           | `64`     | Max number of variables in scope. |
+
+A budget exhaustion is reported as a runtime error and follows the transform's `on_error` policy.
+
+These fields are Rhai-only. Setting them under `runtime = "lua"` or `runtime = "python"` is rejected at config-load time.
+
+## `env` binding
+
+| Field                    | Access                  |
+| ------------------------ | ----------------------- |
+| Logical key              | `env.meta.key`          |
+| Source node id           | `env.meta.source_id`    |
+| Producer timestamp (ms)  | `env.meta.timestamp_ms` |
+| Headers map              | `env.meta.headers`      |
+| Payload                  | `env.payload`           |
+
+`env.payload` is the parsed JSON value — index into it with the usual `[]` syntax.

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,383 @@
+# ============================================================================
+#
+# The configuration produced by default is meant to highlight the features
+# that Zensical provides and to serve as a starting point for your own
+# projects.
+#
+# ============================================================================
+
+[project]
+
+# The site_name is shown in the page header and the browser window title
+#
+# Read more: https://zensical.org/docs/setup/basics/#site_name
+site_name = "Courier"
+
+# The site_description is included in the HTML head and should contain a
+# meaningful description of the site content for use by search engines.
+#
+# Read more: https://zensical.org/docs/setup/basics/#site_description
+site_description = "Async Rust framework for composable data pipelines."
+
+# The site_author attribute. This is used in the HTML head element.
+#
+# Read more: https://zensical.org/docs/setup/basics/#site_author
+site_author = "Courier contributors"
+
+# The site_url is the canonical URL for your site. When building online
+# documentation you should set this.
+# Read more: https://zensical.org/docs/setup/basics/#site_url
+#site_url = "https://gbpagano.github.io/courier/"
+
+# Repository — enables the source link in the header and the "edit this page"
+# button when content.action.edit is enabled.
+repo_name = "gbPagano/courier"
+repo_url = "https://github.com/gbPagano/courier"
+edit_uri = "edit/main/docs/"
+
+# The copyright notice appears in the page footer and can contain an HTML
+# fragment.
+#
+# Read more: https://zensical.org/docs/setup/basics/#copyright
+copyright = """
+Copyright &copy; 2026 Courier contributors
+"""
+
+# Zensical supports both implicit navigation and explicitly defined navigation.
+# If you decide not to define a navigation here then Zensical will simply
+# derive the navigation structure from the directory structure of your
+# "docs_dir". The definition below demonstrates how a navigation structure
+# can be defined using TOML syntax.
+#
+# Read more: https://zensical.org/docs/setup/navigation/
+nav = [
+    { "Home" = "index.md" },
+    { "Getting Started" = [
+        { "Overview" = "getting-started/index.md" },
+        { "Installation" = "getting-started/installation.md" },
+        { "Quickstart" = "getting-started/quickstart.md" },
+    ] },
+    { "Configuration" = [
+        { "Overview" = "configuration/index.md" },
+        { "Pipelines" = "configuration/pipelines.md" },
+        { "Error Handling & Retry" = "configuration/error-handling.md" },
+    ] },
+    { "Concepts" = [
+        { "Overview" = "concepts/index.md" },
+        { "Architecture" = "concepts/architecture.md" },
+        { "Envelope" = "concepts/envelope.md" },
+        { "Backpressure" = "concepts/backpressure.md" },
+    ] },
+    { "Components" = [
+        { "Overview" = "components/index.md" },
+        { "Sources" = "components/sources.md" },
+        { "Transforms" = "components/transforms.md" },
+        { "Sinks" = "components/sinks.md" },
+    ] },
+    { "Scripting" = [
+        { "Overview" = "scripting/index.md" },
+        { "Rhai" = "scripting/rhai.md" },
+        { "Lua" = "scripting/lua.md" },
+        { "Python" = "scripting/python.md" },
+    ] },
+    { "Examples" = "examples.md" },
+    { "Contributing" = "contributing.md" },
+]
+
+# With the "extra_css" option you can add your own CSS styling to customize
+# your Zensical project according to your needs. You can add any number of
+# CSS files.
+#
+# The path provided should be relative to the "docs_dir".
+#
+# Read more: https://zensical.org/docs/customization/#additional-css
+extra_css = ["assets/stylesheets/extra.css"]
+
+# With the `extra_javascript` option you can add your own JavaScript to your
+# project to customize the behavior according to your needs.
+#
+# The path provided should be relative to the "docs_dir".
+#
+# Read more: https://zensical.org/docs/customization/#additional-javascript
+#extra_javascript = ["javascripts/extra.js"]
+
+# ----------------------------------------------------------------------------
+# Section for configuring theme options
+# ----------------------------------------------------------------------------
+[project.theme]
+
+# change this to "classic" to use the traditional Material for MkDocs look.
+#variant = "classic"
+
+# Zensical allows you to override specific blocks, partials, or whole
+# templates as well as to define your own templates. To do this, uncomment
+# the custom_dir setting below and set it to a directory in which you
+# keep your template overrides.
+#
+# Read more:
+# - https://zensical.org/docs/customization/#extending-the-theme
+custom_dir = "docs/overrides"
+
+# With the "favicon" option you can set your own image to use as the icon
+# browsers will use in the browser title bar or tab bar. The path provided
+# must be relative to the "docs_dir".
+#
+# Read more:
+# - https://zensical.org/docs/setup/logo-and-icons/#favicon
+# - https://developer.mozilla.org/en-US/docs/Glossary/Favicon
+#
+#favicon = "images/favicon.png"
+
+# Zensical supports more than 60 different languages. This means that the
+# labels and tooltips that Zensical's templates produce are translated.
+# The "language" option allows you to set the language used. This language
+# is also indicated in the HTML head element to help with accessibility
+# and guide search engines and translation tools.
+#
+# The default language is "en" (English). It is possible to create
+# sites with multiple languages and configure a language selector. See
+# the documentation for details.
+#
+# Read more:
+# - https://zensical.org/docs/setup/language/
+#
+language = "en"
+
+# Zensical provides a number of feature toggles that change the behavior
+# of the documentation site.
+features = [
+    # Zensical includes an announcement bar. This feature allows users to
+    # dismiss it when they have read the announcement.
+    # https://zensical.org/docs/setup/header/#announcement-bar
+    "announce.dismiss",
+
+    # If you have a repository configured and turn on this feature, Zensical
+    # will generate an edit button for the page. This works for common
+    # repository hosting services.
+    # https://zensical.org/docs/setup/repository/#content-actions
+    "content.action.edit",
+
+    # If you have a repository configured and turn on this feature, Zensical
+    # will generate a button that allows the user to view the Markdown
+    # code for the current page.
+    # https://zensical.org/docs/setup/repository/#content-actions
+    "content.action.view",
+
+    # Code annotations allow you to add an icon with a tooltip to your
+    # code blocks to provide explanations at crucial points.
+    # https://zensical.org/docs/authoring/code-blocks/#code-annotations
+    "content.code.annotate",
+
+    # This feature turns on a button in code blocks that allow users to
+    # copy the content to their clipboard without first selecting it.
+    # https://zensical.org/docs/authoring/code-blocks/#code-copy-button
+    "content.code.copy",
+
+    # Code blocks can include a button to allow for the selection of line
+    # ranges by the user.
+    # https://zensical.org/docs/authoring/code-blocks/#code-selection-button
+    "content.code.select",
+
+    # Zensical can render footnotes as inline tooltips, so the user can read
+    # the footnote without leaving the context of the document.
+    # https://zensical.org/docs/authoring/footnotes/#footnote-tooltips
+    "content.footnote.tooltips",
+
+    # If you have many content tabs that have the same titles (e.g., "Python",
+    # "JavaScript", "Cobol"), this feature causes all of them to switch to
+    # at the same time when the user chooses their language in one.
+    # https://zensical.org/docs/authoring/content-tabs/#linked-content-tabs
+    "content.tabs.link",
+
+    # With this feature enabled users can add tooltips to links that will be
+    # displayed when the mouse pointer hovers the link.
+    # https://zensical.org/docs/authoring/tooltips/#improved-tooltips
+    "content.tooltips",
+
+    # With this feature enabled, Zensical will automatically hide parts
+    # of the header when the user scrolls past a certain point.
+    # https://zensical.org/docs/setup/header/#automatic-hiding
+    # "header.autohide",
+
+    # Turn on this feature to expand all collapsible sections in the
+    # navigation sidebar by default.
+    # https://zensical.org/docs/setup/navigation/#navigation-expansion
+    # "navigation.expand",
+
+    # This feature turns on navigation elements in the footer that allow the
+    # user to navigate to a next or previous page.
+    # https://zensical.org/docs/setup/footer/#navigation
+    "navigation.footer",
+
+    # When section index pages are enabled, documents can be directly attached
+    # to sections, which is particularly useful for providing overview pages.
+    # https://zensical.org/docs/setup/navigation/#section-index-pages
+    "navigation.indexes",
+
+    # When instant navigation is enabled, clicks on all internal links will be
+    # intercepted and dispatched via XHR without fully reloading the page.
+    # https://zensical.org/docs/setup/navigation/#instant-navigation
+    "navigation.instant",
+
+    # With instant prefetching, your site will start to fetch a page once the
+    # user hovers over a link. This will reduce the perceived loading time
+    # for the user.
+    # https://zensical.org/docs/setup/navigation/#instant-prefetching
+    "navigation.instant.prefetch",
+
+    # In order to provide a better user experience on slow connections when
+    # using instant navigation, a progress indicator can be enabled.
+    # https://zensical.org/docs/setup/navigation/#progress-indicator
+    #"navigation.instant.progress",
+
+    # When navigation paths are activated, a breadcrumb navigation is rendered
+    # above the title of each page
+    # https://zensical.org/docs/setup/navigation/#navigation-path
+    "navigation.path",
+
+    # When pruning is enabled, only the visible navigation items are included
+    # in the rendered HTML, reducing the size of the built site by 33% or more.
+    # https://zensical.org/docs/setup/navigation/#navigation-pruning
+    #"navigation.prune",
+
+    # When sections are enabled, top-level sections are rendered as groups in
+    # the sidebar for viewports above 1220px, but remain as-is on mobile.
+    # https://zensical.org/docs/setup/navigation/#navigation-sections
+    "navigation.sections",
+
+    # When tabs are enabled, top-level sections are rendered in a menu layer
+    # below the header for viewports above 1220px, but remain as-is on mobile.
+    # https://zensical.org/docs/setup/navigation/#navigation-tabs
+    "navigation.tabs",
+
+    # When sticky tabs are enabled, navigation tabs will lock below the header
+    # and always remain visible when scrolling down.
+    # https://zensical.org/docs/setup/navigation/#sticky-navigation-tabs
+    #"navigation.tabs.sticky",
+
+    # A back-to-top button can be shown when the user, after scrolling down,
+    # starts to scroll up again.
+    # https://zensical.org/docs/setup/navigation/#back-to-top-button
+    "navigation.top",
+
+    # When anchor tracking is enabled, the URL in the address bar is
+    # automatically updated with the active anchor as highlighted in the table
+    # of contents.
+    # https://zensical.org/docs/setup/navigation/#anchor-tracking
+    "navigation.tracking",
+
+    # When search highlighting is enabled and a user clicks on a search result,
+    # Zensical will highlight all occurrences after following the link.
+    # https://zensical.org/docs/setup/search/#search-highlighting
+    "search.highlight",
+
+    # When anchor following for the table of contents is enabled, the sidebar
+    # is automatically scrolled so that the active anchor is always visible.
+    # https://zensical.org/docs/setup/navigation/#anchor-following
+    # "toc.follow",
+
+    # When navigation integration for the table of contents is enabled, it is
+    # always rendered as part of the navigation sidebar on the left.
+    # https://zensical.org/docs/setup/navigation/#navigation-integration
+    #"toc.integrate",
+]
+
+# ----------------------------------------------------------------------------
+# You can configure your own logo to be shown in the header using the "logo"
+# option in the "theme" subsection. The logo must be a relative path to a file
+# in your "docs_dir", e.g., to use `docs/assets/logo.png` you would set:
+# ----------------------------------------------------------------------------
+#logo = "assets/logo.png"
+
+# ----------------------------------------------------------------------------
+# If you don't have a dedicated project logo, you can use a built-in icon from
+# the icon sets shipped in Zensical. Please note that the setting lives in a
+# different subsection, and that the above take precedence over the icon.
+#
+# Read more:
+# - https://zensical.org/docs/setup/logo-and-icons
+# - https://github.com/zensical/ui/tree/master/dist/.icons
+# ----------------------------------------------------------------------------
+#[project.theme.icon]
+#logo = "lucide/smile"
+
+# ----------------------------------------------------------------------------
+# In the "font" subsection you can configure the fonts used. By default, fonts
+# are loaded from Google Fonts, giving you a wide range of choices from a set
+# of suitably licensed fonts. There are options for a normal text font and for
+# a monospaced font used in code blocks.
+# ----------------------------------------------------------------------------
+#[project.theme.font]
+#text = "Inter"
+#code = "Jetbrains Mono"
+
+# ----------------------------------------------------------------------------
+# In the "palette" subsection you can configure options for the color scheme.
+# You can configure different color schemes, e.g., to turn on dark mode,
+# that the user can switch between. Each color scheme can be further
+# customized.
+#
+# Read more:
+# - https://zensical.org/docs/setup/colors/
+# ----------------------------------------------------------------------------
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+# ----------------------------------------------------------------------------
+# The "extra" section contains miscellaneous settings.
+# ----------------------------------------------------------------------------
+[[project.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/gbPagano/courier"
+name = "Courier on GitHub"
+
+# ----------------------------------------------------------------------------
+# In this section you can configure the Markdown extensions that are used when
+# rendering your documentation. We enable the most useful extensions by default,
+# but you can customize this list to your needs.
+#
+# Read more:
+# - https://zensical.org/docs/setup/extensions/
+# ----------------------------------------------------------------------------
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.arithmatex]
+generic = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+emoji_generator = "zensical.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]


### PR DESCRIPTION
## Summary

  - Adds a Markdown-first documentation site at `docs/`, built with [Zensical](https://zensical.org).
  - Wires `zensical.toml` with explicit navigation (tabs), repo edit links, dark/light palette toggle, and the standard set of Markdown extensions.
  - Ships a custom landing page with a hero override (`docs/overrides/home.html` + `docs/assets/stylesheets/extra.css`) and a card grid into the rest of the docs.
  - Adds a GitHub Actions workflow (`.github/workflows/docs.yml`) that builds the site and publishes to GitHub Pages on push to `main`.

  ## Information architecture

  Sections seeded with starter content, ready to grow:

  - **Home** — hero + card grid.
  - **Getting Started** — Installation, Quickstart.
  - **Configuration** — Pipelines schema, Error Handling & Retry.
  - **Concepts** — Architecture, Envelope, Backpressure.
  - **Components** — Sources, Transforms, Sinks.
  - **Scripting** — Rhai, Lua, Python.
  - **Examples** — End-to-end pipeline recipes.
  - **Contributing** — Dev workflow, plugin authoring, docs site how-to.

  ## Local preview

  ```bash
  uvx zensical serve         # live-reload preview at http://127.0.0.1:8000
  uvx zensical build --clean # static build into ./site

  Notes

  - docs/overrides/ holds Jinja template overrides for the hero. Zensical copies non-Markdown files under docs/ verbatim into the build, so a stray site/overrides/home.html ends up in the
  output. The CI workflow strips it before deploy; locally, rm -rf site/overrides mirrors that. Documented in docs/contributing.md.
  - site_url is left commented in zensical.toml — uncomment once the GitHub Pages URL is known after the first deploy.
  - /site and /.cache added to .gitignore.